### PR TITLE
Add MkDocs integration to cookiecutter template

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/docs.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between
+# the run in-progress and latest queued.  However, do NOT cancel
+# in-progress runs as we want to allow these production deployments to
+# complete.
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install {{ cookiecutter.python_version_dev }}
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Build documentation
+        run: uv run mkdocs build --strict
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+{%- raw %}      
+      url: ${{ steps.deployment.outputs.page_url }}
+{%- endraw %}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/{{ cookiecutter.package_name }}/docs/changelog.md
+++ b/{{ cookiecutter.package_name }}/docs/changelog.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to {{ cookiecutter.project_name }} will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial release of {{ cookiecutter.project_name }}
+- Command-line interface with Typer
+- Structured logging with Loguru
+{% if cookiecutter.use_pydantic_settings -%}
+- Configuration management with Pydantic Settings
+{% endif -%}
+- Type checking with mypy
+- Code quality tools (ruff, pytest)
+- Comprehensive documentation with MkDocs
+
+### Changed
+- Nothing yet
+
+### Deprecated
+- Nothing yet
+
+### Removed
+- Nothing yet
+
+### Fixed
+- Nothing yet
+
+### Security
+- Nothing yet
+
+## [{{ cookiecutter.project_version }}] - {% now 'utc', '%Y-%m-%d' %}
+
+### Added
+- Initial release
+
+[Unreleased]: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/compare/v{{ cookiecutter.project_version }}...HEAD
+[{{ cookiecutter.project_version }}]: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/releases/tag/v{{ cookiecutter.project_version }}

--- a/{{ cookiecutter.package_name }}/docs/contributing.md
+++ b/{{ cookiecutter.package_name }}/docs/contributing.md
@@ -1,0 +1,180 @@
+# Contributing
+
+We welcome contributions to {{ cookiecutter.project_name }}! This guide will help you get started.
+
+## Development Setup
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/{{ cookiecutter.package_name }}.git
+cd {{ cookiecutter.package_name }}
+```
+
+3. Install dependencies using `uv`:
+
+```bash
+uv sync
+```
+
+4. Install pre-commit hooks:
+
+```bash
+uv run pre-commit install
+```
+
+## Development Workflow
+
+### Code Quality
+
+We use several tools to maintain code quality:
+
+```bash
+# Run all code quality checks
+uv run poe check
+
+# Or run individual tools
+uv run poe ruff      # Linting and formatting
+uv run poe mypy      # Type checking
+uv run poe ty        # Additional type checking
+```
+
+### Testing
+
+Run the test suite:
+
+```bash
+uv run poe test
+```
+
+Run tests with coverage:
+
+```bash
+uv run poe coverage
+```
+
+### Documentation
+
+Build and serve the documentation locally:
+
+```bash
+uv run mkdocs serve
+```
+
+The documentation will be available at `http://localhost:8000`.
+
+## Making Changes
+
+1. Create a new branch for your feature or bugfix:
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+2. Make your changes, ensuring you:
+   - Follow the existing code style
+   - Add tests for new functionality
+   - Update documentation as needed
+   - Keep commits focused and well-described
+
+3. Run the full test suite:
+
+```bash
+uv run poe qc
+```
+
+4. Commit your changes:
+
+```bash
+git add .
+git commit -m "Add your descriptive commit message"
+```
+
+5. Push to your fork:
+
+```bash
+git push origin feature/your-feature-name
+```
+
+6. Create a Pull Request on GitHub
+
+## Code Style
+
+- We use `ruff` for linting and formatting
+- Follow PEP 8 guidelines
+- Use type hints for all functions and methods
+- Write docstrings for all public functions and classes
+- Keep functions focused and reasonably sized
+
+## Testing Guidelines
+
+- Write tests for all new functionality
+- Use descriptive test names
+- Test both positive and negative cases
+- Use fixtures for common test data
+- Mock external dependencies
+
+## Documentation
+
+- Update documentation for any API changes
+- Add examples for new features
+- Keep documentation clear and concise
+- Use proper markdown formatting
+
+## Submitting Changes
+
+### Pull Request Process
+
+1. Ensure your PR description clearly describes the problem and solution
+2. Include the relevant issue number if applicable
+3. Make sure all tests pass and code quality checks pass
+4. Request review from maintainers
+5. Address any feedback promptly
+
+### Commit Messages
+
+Use clear, descriptive commit messages:
+
+```
+Add support for configuration files
+
+- Implement ConfigLoader class
+- Add tests for configuration loading
+- Update documentation with examples
+```
+
+## Release Process
+
+Releases are managed by maintainers using the following commands:
+
+```bash
+# Patch release (bug fixes)
+uv run poe publish_patch
+
+# Minor release (new features)
+uv run poe publish_minor
+
+# Major release (breaking changes)
+uv run poe publish_major
+```
+
+## Getting Help
+
+- Create an issue on GitHub for bugs or feature requests
+- Join discussions in existing issues
+- Reach out to maintainers for guidance
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We want to maintain a welcoming environment for all contributors.
+
+## License
+
+By contributing to {{ cookiecutter.project_name }}, you agree that your contributions will be licensed under the same license as the project.
+
+## Recognition
+
+Contributors will be recognized in the project's README and release notes.
+
+Thank you for contributing to {{ cookiecutter.project_name }}!

--- a/{{ cookiecutter.package_name }}/docs/gen_ref_pages.py
+++ b/{{ cookiecutter.package_name }}/docs/gen_ref_pages.py
@@ -1,0 +1,35 @@
+"""Generate the code reference pages and navigation."""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+src = Path(__file__).parent.parent / "src"
+package_name = "{{ cookiecutter.package_name }}"
+
+for path in sorted(src.rglob("*.py")):
+    module_path = path.relative_to(src).with_suffix("")
+    doc_path = path.relative_to(src).with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1] == "__main__":
+        continue
+
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"::: {ident}")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/{{ cookiecutter.package_name }}/docs/getting-started/configuration.md
+++ b/{{ cookiecutter.package_name }}/docs/getting-started/configuration.md
@@ -1,0 +1,77 @@
+# Configuration
+
+{% if cookiecutter.use_pydantic_settings -%}
+{{ cookiecutter.project_name }} uses Pydantic Settings for configuration management, which allows you to configure the application using environment variables, configuration files, or both.
+
+## Environment Variables
+
+You can configure {{ cookiecutter.package_name }} using environment variables:
+
+```bash
+export {{ cookiecutter.package_name.upper() }}_SETTING_NAME=value
+{{ cookiecutter.cli_name }} [command]
+```
+
+## Configuration File
+
+You can also use a configuration file. Create a `.env` file in your project directory:
+
+```bash
+# .env
+{{ cookiecutter.package_name.upper() }}_SETTING_NAME=value
+```
+
+## Available Settings
+
+The following settings are available:
+
+### Logging Settings
+
+- `{{ cookiecutter.package_name.upper() }}_LOG_LEVEL`: Set the logging level (default: INFO)
+{% if cookiecutter.log_to_file -%}
+- `{{ cookiecutter.package_name.upper() }}_LOG_FILE`: Path to log file (default: {{ cookiecutter.package_name }}.log)
+{% endif -%}
+
+### Application Settings
+
+Add your application-specific settings here.
+
+## Priority Order
+
+Settings are loaded in the following priority order (highest to lowest):
+
+1. Environment variables
+2. Configuration file (`.env`)
+3. Default values
+
+## Example
+
+```bash
+# Set log level to DEBUG
+export {{ cookiecutter.package_name.upper() }}_LOG_LEVEL=DEBUG
+
+# Run the CLI
+{{ cookiecutter.cli_name }} [command]
+```
+
+{% else -%}
+{{ cookiecutter.project_name }} uses simple configuration through command-line arguments and environment variables.
+
+## Environment Variables
+
+You can configure logging using environment variables:
+
+```bash
+export LOG_LEVEL=DEBUG
+{{ cookiecutter.cli_name }} [command]
+```
+
+## Command Line Options
+
+Most configuration is done through command-line arguments. Use the `--help` flag to see available options:
+
+```bash
+{{ cookiecutter.cli_name }} --help
+```
+
+{% endif -%}

--- a/{{ cookiecutter.package_name }}/docs/getting-started/installation.md
+++ b/{{ cookiecutter.package_name }}/docs/getting-started/installation.md
@@ -1,0 +1,47 @@
+# Installation
+
+{{ cookiecutter.project_name }} requires Python {{ cookiecutter.python_version_min }} or later.
+
+## Install from PyPI
+
+The easiest way to install {{ cookiecutter.package_name }} is from PyPI:
+
+```bash
+pip install {{ cookiecutter.package_name }}
+```
+
+## Install from Source
+
+You can also install from source:
+
+```bash
+git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}.git
+cd {{ cookiecutter.package_name }}
+pip install -e .
+```
+
+## Development Installation
+
+For development, we recommend using `uv`:
+
+```bash
+git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}.git
+cd {{ cookiecutter.package_name }}
+uv sync
+```
+
+This will install all dependencies including development tools.
+
+## Verify Installation
+
+After installation, verify that {{ cookiecutter.package_name }} is working:
+
+```bash
+{{ cookiecutter.cli_name }} --version
+```
+
+You should see the version number displayed.
+
+## Next Steps
+
+Now that you have {{ cookiecutter.package_name }} installed, check out the [Quick Start](quickstart.md) guide to learn how to use it.

--- a/{{ cookiecutter.package_name }}/docs/getting-started/quickstart.md
+++ b/{{ cookiecutter.package_name }}/docs/getting-started/quickstart.md
@@ -1,0 +1,50 @@
+# Quick Start
+
+This guide will help you get started with {{ cookiecutter.project_name }} quickly.
+
+## Basic Usage
+
+After [installing](installation.md) {{ cookiecutter.package_name }}, you can use the CLI:
+
+```bash
+{{ cookiecutter.cli_name }} --help
+```
+
+This will show you all available commands and options.
+
+## Common Commands
+
+Here are some common commands to get you started:
+
+### Help
+
+Get help for any command:
+
+```bash
+{{ cookiecutter.cli_name }} --help
+{{ cookiecutter.cli_name }} [command] --help
+```
+
+### Version
+
+Check the version:
+
+```bash
+{{ cookiecutter.cli_name }} --version
+```
+
+{% if cookiecutter.use_pydantic_settings -%}
+## Configuration
+
+{{ cookiecutter.project_name }} can be configured using environment variables or a configuration file. See [Configuration](configuration.md) for details.
+{% endif -%}
+
+## Examples
+
+For more detailed examples, see the [Examples](../user-guide/examples.md) page.
+
+## Next Steps
+
+- Learn more about the [CLI interface](../user-guide/cli.md)
+- Check out the [API Reference](../reference/)
+- Read the [Contributing Guide](../contributing.md) if you want to contribute

--- a/{{ cookiecutter.package_name }}/docs/index.md
+++ b/{{ cookiecutter.package_name }}/docs/index.md
@@ -1,0 +1,57 @@
+# {{ cookiecutter.project_name }}
+
+{{ cookiecutter.project_short_description }}
+
+## Overview
+
+{{ cookiecutter.project_name }} is a Python package that provides a command-line interface for [brief description of what your package does].
+
+## Quick Start
+
+Install {{ cookiecutter.package_name }} using pip:
+
+```bash
+pip install {{ cookiecutter.package_name }}
+```
+
+Then run the CLI:
+
+```bash
+{{ cookiecutter.cli_name }} --help
+```
+
+## Features
+
+- Modern Python packaging with `uv` support
+- CLI interface built with Typer
+- Structured logging with Loguru
+{% if cookiecutter.use_pydantic_settings -%}
+- Configuration management with Pydantic Settings
+{% endif -%}
+- Type checking with mypy
+- Code quality tools (ruff, pytest)
+- Automated testing and CI/CD
+
+## Installation
+
+For detailed installation instructions, see [Installation](getting-started/installation.md).
+
+## Documentation
+
+- [Getting Started](getting-started/quickstart.md) - Quick start guide
+- [User Guide](user-guide/cli.md) - Detailed usage instructions
+- [API Reference](reference/) - Complete API documentation
+- [Contributing](contributing.md) - How to contribute to this project
+
+## License
+
+{% if cookiecutter.license != 'no-license' -%}
+This project is licensed under the {{ cookiecutter.license }} license.
+{% else -%}
+This project is not licensed.
+{% endif -%}
+
+## Support
+
+- [GitHub Issues](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/issues)
+- [GitHub Repository](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }})

--- a/{{ cookiecutter.package_name }}/docs/user-guide/cli.md
+++ b/{{ cookiecutter.package_name }}/docs/user-guide/cli.md
@@ -1,0 +1,87 @@
+# CLI Usage
+
+{{ cookiecutter.project_name }} provides a command-line interface built with Typer.
+
+## Basic Syntax
+
+```bash
+{{ cookiecutter.cli_name }} [OPTIONS] [COMMAND] [ARGS]...
+```
+
+## Global Options
+
+The following options are available for all commands:
+
+- `--help`: Show help message and exit
+- `--version`: Show version and exit
+
+## Commands
+
+### Help
+
+Get help for the CLI or any specific command:
+
+```bash
+{{ cookiecutter.cli_name }} --help
+{{ cookiecutter.cli_name }} [command] --help
+```
+
+### Version
+
+Display the version:
+
+```bash
+{{ cookiecutter.cli_name }} --version
+```
+
+## Self-Subcommands
+
+{{ cookiecutter.project_name }} uses a self-subcommand pattern, where the main command can also act as a subcommand. This provides a clean and intuitive interface.
+
+## Logging
+
+The CLI uses structured logging with Loguru. You can control the log level using:
+
+```bash
+{{ cookiecutter.cli_name }} --log-level DEBUG [command]
+```
+
+{% if cookiecutter.log_to_file -%}
+## Log Files
+
+By default, logs are also written to `{{ cookiecutter.package_name }}.log` in the current directory.
+{% endif -%}
+
+## Examples
+
+For specific usage examples, see the [Examples](examples.md) page.
+
+## Error Handling
+
+The CLI provides clear error messages and appropriate exit codes:
+
+- `0`: Success
+- `1`: General error
+- `2`: Command line usage error
+
+## Shell Completion
+
+{{ cookiecutter.project_name }} supports shell completion for bash, zsh, and fish. To enable it:
+
+### Bash
+
+```bash
+eval "$(_{{ cookiecutter.cli_name.upper() }}_COMPLETE=bash_source {{ cookiecutter.cli_name }})"
+```
+
+### Zsh
+
+```bash
+eval "$(_{{ cookiecutter.cli_name.upper() }}_COMPLETE=zsh_source {{ cookiecutter.cli_name }})"
+```
+
+### Fish
+
+```bash
+eval "$(_{{ cookiecutter.cli_name.upper() }}_COMPLETE=fish_source {{ cookiecutter.cli_name }})"
+```

--- a/{{ cookiecutter.package_name }}/docs/user-guide/examples.md
+++ b/{{ cookiecutter.package_name }}/docs/user-guide/examples.md
@@ -1,0 +1,133 @@
+# Examples
+
+This page provides practical examples of using {{ cookiecutter.project_name }}.
+
+## Basic Usage
+
+### Getting Help
+
+```bash
+# Show main help
+{{ cookiecutter.cli_name }} --help
+
+# Show help for a specific command
+{{ cookiecutter.cli_name }} [command] --help
+```
+
+### Check Version
+
+```bash
+{{ cookiecutter.cli_name }} --version
+```
+
+## Advanced Usage
+
+### Using with Different Log Levels
+
+```bash
+# Run with debug logging
+{{ cookiecutter.cli_name }} --log-level DEBUG [command]
+
+# Run with minimal logging
+{{ cookiecutter.cli_name }} --log-level ERROR [command]
+```
+
+{% if cookiecutter.use_pydantic_settings -%}
+### Using with Configuration
+
+```bash
+# Set configuration via environment variables
+export {{ cookiecutter.package_name.upper() }}_SETTING_NAME=value
+{{ cookiecutter.cli_name }} [command]
+
+# Or create a .env file
+echo "{{ cookiecutter.package_name.upper() }}_SETTING_NAME=value" > .env
+{{ cookiecutter.cli_name }} [command]
+```
+{% endif -%}
+
+## Common Workflows
+
+### Example Workflow 1
+
+```bash
+# Step 1: Initialize
+{{ cookiecutter.cli_name }} init
+
+# Step 2: Process
+{{ cookiecutter.cli_name }} process --input file.txt
+
+# Step 3: Output
+{{ cookiecutter.cli_name }} output --format json
+```
+
+### Example Workflow 2
+
+```bash
+# One-liner example
+{{ cookiecutter.cli_name }} process --input file.txt --output result.txt --verbose
+```
+
+## Error Handling Examples
+
+### Common Errors
+
+```bash
+# File not found
+{{ cookiecutter.cli_name }} process --input nonexistent.txt
+# Error: Input file 'nonexistent.txt' not found
+
+# Invalid option
+{{ cookiecutter.cli_name }} --invalid-option
+# Error: No such option: --invalid-option
+```
+
+### Debugging
+
+```bash
+# Run with debug logging to troubleshoot
+{{ cookiecutter.cli_name }} --log-level DEBUG process --input file.txt
+```
+
+## Integration Examples
+
+### Use in Scripts
+
+```bash
+#!/bin/bash
+set -e
+
+# Check if {{ cookiecutter.package_name }} is installed
+if ! command -v {{ cookiecutter.cli_name }} &> /dev/null; then
+    echo "{{ cookiecutter.package_name }} is not installed"
+    exit 1
+fi
+
+# Run the command
+{{ cookiecutter.cli_name }} process --input "$1" --output "$2"
+echo "Processing complete"
+```
+
+### Use with Make
+
+```makefile
+.PHONY: process
+process:
+	{{ cookiecutter.cli_name }} process --input input.txt --output output.txt
+
+.PHONY: clean
+clean:
+	rm -f output.txt {{ cookiecutter.package_name }}.log
+```
+
+## Performance Tips
+
+- Use appropriate log levels in production
+- Process files in batches when possible
+- Use configuration files for repeated settings
+
+## Next Steps
+
+- Learn more about the [API Reference](../reference/)
+- Check out the [Contributing Guide](../contributing.md)
+- Visit the [GitHub repository](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }})

--- a/{{ cookiecutter.package_name }}/mkdocs.yml
+++ b/{{ cookiecutter.package_name }}/mkdocs.yml
@@ -1,0 +1,105 @@
+site_name: {{ cookiecutter.project_name }}
+site_description: {{ cookiecutter.project_short_description }}
+site_author: {{ cookiecutter.full_name }}
+site_url: https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.package_name }}/
+
+repo_name: {{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
+repo_url: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - toc.integrate
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: true
+            show_bases: true
+            show_root_heading: true
+            show_object_full_path: true
+            show_category_heading: true
+            show_if_no_docstring: true
+            inherited_members: true
+            members_order: source
+            separate_signature: true
+            unwrap_annotated: true
+            filters: ["!^_"]
+            merge_init_into_class: true
+            docstring_section_style: spacy
+            signature_crossrefs: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Configuration: getting-started/configuration.md
+  - User Guide:
+    - CLI Usage: user-guide/cli.md
+    - Examples: user-guide/examples.md
+  - API Reference: reference/
+  - Contributing: contributing.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - attr_list
+  - md_in_html
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  version:
+    provider: mike
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/{{ cookiecutter.package_name }}/

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -29,9 +29,9 @@ classifiers = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repository }}#readme"
-Issues = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repository }}/issues"
-Source = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repository }}"
+Documentation = "https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.package_name }}/"
+Issues = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/issues"
+Source = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}"
 
 
 [project.scripts]
@@ -59,6 +59,15 @@ dev = [
     "pytest-cov",
     "ruff",
     "ty",
+]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-autorefs",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
+    "mkdocs-section-index",
+    "mkdocstrings[python]",
 ]
 
 [tool.poe.tasks]
@@ -137,6 +146,17 @@ clean.help = "[Clean] Remove testing, build and code quality artifacts."
 
 tree.cmd = "tree . -a -I .venv -I .git -I .ruff_cache"
 tree.help = "List project files in tree format."
+
+# Documentation
+
+docs-serve.cmd = "mkdocs serve"
+docs-serve.help = "[Documentation] Serve documentation locally for development."
+
+docs-build.cmd = "mkdocs build"
+docs-build.help = "[Documentation] Build documentation for production."
+
+docs-deploy.cmd = "mkdocs gh-deploy"
+docs-deploy.help = "[Documentation] Deploy documentation to GitHub Pages."
 
 # Tool Options
 


### PR DESCRIPTION
## Summary
- Added comprehensive MkDocs integration to the cookiecutter template
- Configured automated GitHub Pages deployment
- Added complete documentation structure with starter content

## Changes Made
- **Dependencies**: Added MkDocs and related packages to `pyproject.toml`
- **Configuration**: Created `mkdocs.yml` with Material theme and plugins
- **Documentation**: Added complete docs structure with starter content
- **CI/CD**: Added GitHub Actions workflow for automated deployment
- **Poe Tasks**: Added `docs-serve`, `docs-build`, and `docs-deploy` tasks
- **URLs**: Updated project URLs to point to GitHub Pages

## Features
- Material Design theme with dark/light mode
- Auto-generated API documentation from docstrings
- Search functionality with highlighting
- Automated deployment to GitHub Pages
- Professional documentation structure

## Test Plan
- [x] Generated test project successfully builds MkDocs
- [x] All poe tasks work correctly
- [x] Documentation structure is complete and navigable

🤖 Generated with [Claude Code](https://claude.ai/code)